### PR TITLE
Add lfs support and cleaned subset of new subreddits

### DIFF
--- a/project/data/.gitattributes
+++ b/project/data/.gitattributes
@@ -1,0 +1,1 @@
+subreddit_newsubset.zip filter=lfs diff=lfs merge=lfs -text

--- a/project/data/subreddit_newsubset.zip
+++ b/project/data/subreddit_newsubset.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84d49ff58f7df1893b73502deb1457a5e9055cc3cf10685dc524d5c1084d9249
+size 227728072


### PR DESCRIPTION
In order to use lfs you have to have it installed on your computer (https://git-lfs.github.com/) then run "git lfs install". This can be used to submit files larger than 100mb to github.
