### PR TITLE
added nakamoto-LinearSVC test documentation

### DIFF
--- a/project/notebooks/nakamoto-SVM.ipynb
+++ b/project/notebooks/nakamoto-SVM.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import Bags_Of_Words as bw\n",
+    "from sklearn.svm import LinearSVC\n",
+    "from sklearn import metrics\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "train_fp = \"../data/train_set50000.csv\"\n",
+    "test_fp = \"../data/test_set50000.csv\"\n",
+    "\n",
+    "BOW = bw.Bags_Of_Words(train_fp, test_fp, True)\n",
+    "print BOW['test'].shape\n",
+    "print BOW['train'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(train_fp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "clf = LinearSVC(multi_class='crammer_singer').fit(BOW['train'], df.subreddit_index)\n",
+    "predicted = clf.predict(BOW['test'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df_test = pd.read_csv(test_fp)\n",
+    "\n",
+    "print np.mean(predicted == df_test.subreddit_index)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "## Results - Default \n",
+    "Default parameters => penalty='l2', loss='squared_hinge', dual=True, tol=0.0001, C=1.0, multi_class='ovr', fit_intercept=True, intercept_scaling=1, class_weight=None, verbose=0, random_state=None, max_iter=1000\n",
+    "- 1,000  - 72.3%\n",
+    "- 5,000  - 66.28%\n",
+    "- 10,000 - 64.005%\n",
+    "- 20,000 - 64.4925%\n",
+    "- 50,000 - 62.307%"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results - Class Weight = Auto\n",
+    "- 1,000  - 72.25%\n",
+    "- 5,000  - 66.26%\n",
+    "- 10,000 - 64.005%\n",
+    "- 20,000 - 64.4975%\n",
+    "- 50,000 - 62.31%"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results - Penalty = l1 & dual = false\n",
+    "- 1,000  - 68.3%\n",
+    "- 5,000  - 64.92%\n",
+    "- 10,000 - 63.11%\n",
+    "- 20,000 - 63.8325%\n",
+    "- 50,000 - 62.06%"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results - multi_class = 'crammer_singer'\n",
+    "- 1,000  - 71.15%\n",
+    "- 5,000  - 65.9%\n",
+    "- 10,000 - 63.475%\n",
+    "- 20,000 - 63.875%\n",
+    "- 50,000 - 61.764%"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Added my results for SVM tests using LinearSVC as base SVC was proving to be somewhat slow. Results are in the ipython notebook nakamoto-SVM.ipynb and there are several results for different parameter inputs.
